### PR TITLE
[ENG-812] publish pushes to master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,10 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - setup:
-          filters:
-            tags: 
-              only: /^v[0-9]+(\.[0-9]+)*$/
+      - setup
       - test:
           requires:
             - setup
-          filters:
-            tags: 
-              only: /^v[0-9]+(\.[0-9]+)*$/
       - deploy:
           requires:
             - test
@@ -83,6 +77,5 @@ workflows:
           filters:
             # ignore any commit on any branch by default
             branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+(\.[0-9]+)*$/
+              only: 
+                - master


### PR DESCRIPTION
Currently we are publishing on tags. This update will attempt to publish when there is a commit/merge to master.

@traylewin this would now mimic the monorepo work that was done last week.